### PR TITLE
combo meter, potion mixin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ mixin {
     add sourceSets.main, "dungeons_gear.refmap.json"
 }
 
-version = '3.0.8'
+version = '3.0.11'
 group = 'com.infamous.dungeons_gear' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'dungeons_gear-1.16.4'
 

--- a/src/main/java/com/infamous/dungeons_gear/GlobalEvents.java
+++ b/src/main/java/com/infamous/dungeons_gear/GlobalEvents.java
@@ -1,15 +1,14 @@
 package com.infamous.dungeons_gear;
 
 
-import com.infamous.dungeons_gear.capabilities.combo.ComboProvider;
 import com.infamous.dungeons_gear.capabilities.combo.ICombo;
 import com.infamous.dungeons_gear.capabilities.weapon.IWeapon;
-import com.infamous.dungeons_gear.capabilities.weapon.WeaponProvider;
 import com.infamous.dungeons_gear.effects.CustomEffects;
 import com.infamous.dungeons_gear.enchantments.lists.RangedEnchantmentList;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
 import com.infamous.dungeons_gear.init.PotionList;
 import com.infamous.dungeons_gear.interfaces.IArmor;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
 import com.infamous.dungeons_gear.utilties.CapabilityHelper;
 import com.infamous.dungeons_gear.utilties.ModEnchantmentHelper;
@@ -29,31 +28,34 @@ import net.minecraft.potion.Effects;
 import net.minecraft.potion.PotionUtils;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.*;
+import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.Optional;
+
 import static com.infamous.dungeons_gear.DungeonsGear.PROXY;
-import static com.infamous.dungeons_gear.items.RangedWeaponList.*;
 
 
 @Mod.EventBusSubscriber(modid = DungeonsGear.MODID)
 public class GlobalEvents {
 
     @SubscribeEvent
-    public static void onArrowJoinWorld(EntityJoinWorldEvent event){
-        if(event.getEntity() instanceof AbstractArrowEntity){
-            AbstractArrowEntity arrowEntity = (AbstractArrowEntity)event.getEntity();
+    public static void onArrowJoinWorld(EntityJoinWorldEvent event) {
+        if (event.getEntity() instanceof AbstractArrowEntity) {
+            AbstractArrowEntity arrowEntity = (AbstractArrowEntity) event.getEntity();
             //if(arrowEntity.getTags().contains("BonusProjectile") || arrowEntity.getTags().contains("ChainReactionProjectile")) return;
             Entity shooterEntity = arrowEntity.func_234616_v_();
-            if(shooterEntity instanceof LivingEntity){
+            if (shooterEntity instanceof LivingEntity) {
                 LivingEntity shooter = (LivingEntity) shooterEntity;
                 ItemStack mainhandStack = shooter.getHeldItemMainhand();
                 ItemStack offhandStack = shooter.getHeldItemOffhand();
                 // This should guarantee the arrow came from the correct itemstack
-                if(mainhandStack.getItem() instanceof BowItem || mainhandStack.getItem() instanceof CrossbowItem){
+                if (mainhandStack.getItem() instanceof BowItem || mainhandStack.getItem() instanceof CrossbowItem) {
                     handleRangedEnchantments(arrowEntity, shooter, mainhandStack);
-                }
-                else if(offhandStack.getItem() instanceof BowItem || offhandStack.getItem() instanceof CrossbowItem){
+                } else if (offhandStack.getItem() instanceof BowItem || offhandStack.getItem() instanceof CrossbowItem) {
                     handleRangedEnchantments(arrowEntity, shooter, offhandStack);
                 }
             }
@@ -64,26 +66,25 @@ public class GlobalEvents {
         ModEnchantmentHelper.addEnchantmentTagsToArrow(stack, arrowEntity);
 
         int fuseShotLevel = EnchantmentHelper.getEnchantmentLevel(RangedEnchantmentList.FUSE_SHOT, stack);
-        if(stack.getItem() == DeferredItemInit.RED_SNAKE.get()) fuseShotLevel++;
-        if(fuseShotLevel > 0){
+        if (stack.getItem() == DeferredItemInit.RED_SNAKE.get()) fuseShotLevel++;
+        if (fuseShotLevel > 0) {
             IWeapon weaponCap = CapabilityHelper.getWeaponCapability(stack);
-            if(weaponCap == null) return;
+            if (weaponCap == null) return;
             int fuseShotCounter = weaponCap.getFuseShotCounter();
             // 6 - 1, 6 - 2, 6 - 3
             // zero indexing, so subtract 1 as well
-            if(fuseShotCounter == 6 - fuseShotLevel - 1){
+            if (fuseShotCounter == 6 - fuseShotLevel - 1) {
                 arrowEntity.addTag("FuseShot");
                 weaponCap.setFuseShotCounter(0);
-            }
-            else{
+            } else {
                 weaponCap.setFuseShotCounter(fuseShotCounter + 1);
             }
         }
 
-        if(shooter instanceof PlayerEntity){
+        if (shooter instanceof PlayerEntity) {
             PlayerEntity playerEntity = (PlayerEntity) shooter;
             boolean soulsCriticalBoost = ProjectileEffectHelper.soulsCriticalBoost(playerEntity, stack);
-            if(soulsCriticalBoost){
+            if (soulsCriticalBoost) {
                 PROXY.spawnParticles(playerEntity, ParticleTypes.SOUL);
                 arrowEntity.setIsCritical(true);
                 arrowEntity.setDamage(arrowEntity.getDamage() * 2);
@@ -92,27 +93,46 @@ public class GlobalEvents {
     }
 
     @SubscribeEvent
-    public static void onCancelAttackBecauseStunned(LivingAttackEvent event){
-        if(event.getSource().getTrueSource() instanceof PlayerEntity){
-            PlayerEntity attacker = (PlayerEntity)event.getSource().getTrueSource();
-            if(attacker.getActivePotionEffect(CustomEffects.STUNNED) != null)
+    public static void onCancelAttackBecauseStunned(LivingAttackEvent event) {
+        if (event.getSource().getTrueSource() instanceof PlayerEntity) {
+            PlayerEntity attacker = (PlayerEntity) event.getSource().getTrueSource();
+            if (attacker.getActivePotionEffect(CustomEffects.STUNNED) != null)
                 event.setCanceled(true);
         }
     }
 
-
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void comboForceCrit(CriticalHitEvent event) {
+        if (event.getPlayer().getHeldItemMainhand().getItem() instanceof IComboWeapon) {
+            PlayerEntity p = event.getPlayer();
+            ItemStack is = p.getHeldItemMainhand();
+            IComboWeapon ic = (IComboWeapon) is.getItem();
+            ICombo cap = CapabilityHelper.getComboCapability(p);
+            if (cap != null && ic.shouldProcSpecialEffects(is, p, cap.getComboCount())) {
+                event.setResult(Event.Result.ALLOW);
+                event.setDamageModifier(1);
+                cap.setComboCount(cap.getComboCount() % ic.getComboLength(is, p));
+            } else event.setResult(Event.Result.DENY);
+        }
+    }
 
     @SubscribeEvent
-    public static void onStunnedMob(LivingEvent.LivingUpdateEvent event){
-        if(event.getEntityLiving() instanceof MobEntity){
+    public static void resetCombo(LivingEquipmentChangeEvent event) {
+        if (event.getSlot() == EquipmentSlotType.MAINHAND) {
+            Optional.ofNullable(CapabilityHelper.getComboCapability(event.getEntityLiving())).ifPresent((a) -> a.setComboCount(0));
+        }
+    }
+
+    @SubscribeEvent
+    public static void onStunnedMob(LivingEvent.LivingUpdateEvent event) {
+        if (event.getEntityLiving() instanceof MobEntity) {
             MobEntity mobEntity = (MobEntity) event.getEntityLiving();
-            if(mobEntity.getActivePotionEffect(CustomEffects.STUNNED) != null && !mobEntity.getTags().contains("Stunned")){
-                if(!mobEntity.isAIDisabled()){
+            if (mobEntity.getActivePotionEffect(CustomEffects.STUNNED) != null && !mobEntity.getTags().contains("Stunned")) {
+                if (!mobEntity.isAIDisabled()) {
                     mobEntity.setNoAI(true);
                     mobEntity.addTag("Stunned");
                 }
-            }
-            else if(mobEntity.isAIDisabled() && mobEntity.getTags().contains("Stunned")){
+            } else if (mobEntity.isAIDisabled() && mobEntity.getTags().contains("Stunned")) {
                 mobEntity.setNoAI(false);
                 mobEntity.removeTag("Stunned");
             }
@@ -120,19 +140,19 @@ public class GlobalEvents {
     }
 
     @SubscribeEvent
-    public static void onCapabilityAttack(LivingDamageEvent event){
-        if(event.getSource().getTrueSource() instanceof PlayerEntity){
-            PlayerEntity playerEntity = (PlayerEntity)event.getSource().getTrueSource();
+    public static void onCapabilityAttack(LivingDamageEvent event) {
+        if (event.getSource().getTrueSource() instanceof PlayerEntity) {
+            PlayerEntity playerEntity = (PlayerEntity) event.getSource().getTrueSource();
 
             ICombo comboCap = CapabilityHelper.getComboCapability(playerEntity);
-            if(comboCap == null) return;
-            if(comboCap.getShadowForm()){
+            if (comboCap == null) return;
+            if (comboCap.getShadowForm()) {
                 float originalDamage = event.getAmount();
                 event.setAmount(originalDamage * 2.0F);
                 comboCap.setShadowForm(false);
                 playerEntity.removePotionEffect(Effects.INVISIBILITY);
             }
-            if(comboCap.getDynamoMultiplier() > 1.0D){
+            if (comboCap.getDynamoMultiplier() > 1.0D) {
                 double dynamoMultiplier = comboCap.getDynamoMultiplier();
                 float originalDamage = event.getAmount();
                 event.setAmount((float) (originalDamage * dynamoMultiplier));
@@ -142,42 +162,42 @@ public class GlobalEvents {
     }
 
     @SubscribeEvent
-    public static void onShadowFormAdded(LivingEntityUseItemEvent.Finish event){
-        if(PotionUtils.getPotionFromItem(event.getItem()) == PotionList.SHADOW_BREW){
-            if(event.getEntityLiving() instanceof PlayerEntity){
+    public static void onShadowFormAdded(LivingEntityUseItemEvent.Finish event) {
+        if (PotionUtils.getPotionFromItem(event.getItem()) == PotionList.SHADOW_BREW) {
+            if (event.getEntityLiving() instanceof PlayerEntity) {
                 PlayerEntity playerEntity = (PlayerEntity) event.getEntityLiving();
                 ICombo comboCap = CapabilityHelper.getComboCapability(playerEntity);
-                if(comboCap == null) return;
+                if (comboCap == null) return;
                 comboCap.setShadowForm(true);
             }
         }
     }
 
     @SubscribeEvent
-    public static void onShadowFormRemoved(PotionEvent.PotionRemoveEvent event){
-        if(event.getPotion() == Effects.INVISIBILITY){
-            if(event.getEntityLiving() instanceof PlayerEntity){
+    public static void onShadowFormRemoved(PotionEvent.PotionRemoveEvent event) {
+        if (event.getPotion() == Effects.INVISIBILITY) {
+            if (event.getEntityLiving() instanceof PlayerEntity) {
                 PlayerEntity playerEntity = (PlayerEntity) event.getEntityLiving();
                 ICombo comboCap = CapabilityHelper.getComboCapability(playerEntity);
-                if(comboCap == null) return;
+                if (comboCap == null) return;
                 comboCap.setShadowForm(false);
             }
         }
     }
 
     @SubscribeEvent
-    public static void onSoulGatheringItemsXPDrop(LivingExperienceDropEvent event){
-        if(event.getAttackingPlayer() != null){
+    public static void onSoulGatheringItemsXPDrop(LivingExperienceDropEvent event) {
+        if (event.getAttackingPlayer() != null) {
             PlayerEntity attacker = event.getAttackingPlayer();
             int originalExperience = event.getDroppedExperience();
             int additionalExperienceCounter = 0;
             ItemStack mainhand = attacker.getHeldItemMainhand();
             ItemStack offhand = attacker.getHeldItemOffhand();
-            if(mainhand.getItem() instanceof ISoulGatherer){
-                additionalExperienceCounter += ((ISoulGatherer)mainhand.getItem()).getGatherAmount(mainhand);
+            if (mainhand.getItem() instanceof ISoulGatherer) {
+                additionalExperienceCounter += ((ISoulGatherer) mainhand.getItem()).getGatherAmount(mainhand);
             }
-            if(offhand.getItem() instanceof ISoulGatherer){
-                additionalExperienceCounter += ((ISoulGatherer)offhand.getItem()).getGatherAmount(offhand);
+            if (offhand.getItem() instanceof ISoulGatherer) {
+                additionalExperienceCounter += ((ISoulGatherer) offhand.getItem()).getGatherAmount(offhand);
             }
 
             ItemStack helmet = attacker.getItemStackFromSlot(EquipmentSlotType.HEAD);
@@ -187,7 +207,7 @@ public class GlobalEvents {
             float soulsGathered2 = chestplate.getItem() instanceof IArmor ? (float) ((IArmor) chestplate.getItem()).getSoulsGathered() : 0;
             float totalSoulsGathered = soulsGathered * 0.01F + soulsGathered2 * 0.01F;
 
-            if(totalSoulsGathered > 0){
+            if (totalSoulsGathered > 0) {
                 additionalExperienceCounter += originalExperience * totalSoulsGathered;
             }
 

--- a/src/main/java/com/infamous/dungeons_gear/armor/ArmorEvents.java
+++ b/src/main/java/com/infamous/dungeons_gear/armor/ArmorEvents.java
@@ -51,7 +51,7 @@ public class ArmorEvents {
 
     @SubscribeEvent
     public static void onSpelunkerArmorEquipped(LivingEquipmentChangeEvent event) {
-        if (event.getEntityLiving() instanceof PlayerEntity) {
+        if (event.getEntityLiving() instanceof PlayerEntity && event.getSlot() != EquipmentSlotType.OFFHAND && event.getSlot() != EquipmentSlotType.MAINHAND) {
             PlayerEntity playerEntity = (PlayerEntity) event.getEntityLiving();
             World world = playerEntity.getEntityWorld();
             if (event.getTo().getItem() instanceof IArmor) {
@@ -273,6 +273,10 @@ public class ArmorEvents {
             if (comboCap.getLastShoutTimer() > 0) {
                 comboCap.setLastShoutTimer(comboCap.getLastShoutTimer() - 1);
             }
+            if (comboCap.getComboTimer() > 0) {
+                comboCap.setComboTimer(comboCap.getComboTimer() - 1);
+            } else if (comboCap.getComboCount() != 0)
+                comboCap.setComboCount(0);
         }
     }
 

--- a/src/main/java/com/infamous/dungeons_gear/capabilities/combo/Combo.java
+++ b/src/main/java/com/infamous/dungeons_gear/capabilities/combo/Combo.java
@@ -11,15 +11,17 @@ public class Combo implements ICombo {
     private int freezeNearbyTimer;
     private int snowballNearbyTimer;
     private int gravityPulseTimer;
-    private int regenerateTimer;
+    private int comboCount;
     private int arrowsInCounter;
     private int jumpCooldownTimer;
     private int poisonImmunityTimer;
     private double dynamoMultiplier;
     private int lastShoutTimer;
+    private float cachedCooldown;//no need to be saved, it's stored and used in the span of a tick
 
     public Combo() {
         this.comboTimer = 0;
+        this.comboCount = 0;
         //this.ghostForm = false;
         this.shadowForm = false;
         this.flamingArrowCount = 0;
@@ -174,5 +176,25 @@ public class Combo implements ICombo {
     @Override
     public void setDynamoMultiplier(double dynamoMultiplier) {
         this.dynamoMultiplier = dynamoMultiplier;
+    }
+
+    @Override
+    public void setCachedCooldown(float cooldown) {
+        cachedCooldown = cooldown;
+    }
+
+    @Override
+    public int getComboCount() {
+        return comboCount;
+    }
+
+    @Override
+    public void setComboCount(int comboCount) {
+        this.comboCount = comboCount;
+    }
+
+    @Override
+    public float getCachedCooldown() {
+        return cachedCooldown;
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/capabilities/combo/ComboStorage.java
+++ b/src/main/java/com/infamous/dungeons_gear/capabilities/combo/ComboStorage.java
@@ -14,6 +14,7 @@ public class ComboStorage implements Capability.IStorage<ICombo> {
     public INBT writeNBT(Capability<ICombo> capability, ICombo instance, Direction side) {
         CompoundNBT tag = new CompoundNBT();
         tag.putInt("comboTimer", instance.getComboTimer());
+        tag.putInt("comboCount", instance.getComboCount());
         //tag.putBoolean("ghostForm", instance.getGhostForm());
         tag.putBoolean("shadowForm", instance.getShadowForm());
         tag.putInt("flamingArrowsCount", instance.getFlamingArrowsCount());
@@ -34,6 +35,7 @@ public class ComboStorage implements Capability.IStorage<ICombo> {
     public void readNBT(Capability<ICombo> capability, ICombo instance, Direction side, INBT nbt) {
         CompoundNBT tag = (CompoundNBT) nbt;
         instance.setComboTimer(tag.getInt("comboTimer"));
+        instance.setComboCount(tag.getInt("comboCount"));
         //instance.setGhostForm(tag.getBoolean("ghostForm"));
         instance.setShadowForm(tag.getBoolean("shadowForm"));
         instance.setFlamingArrowsCount(tag.getInt("flamingArrowsCount"));

--- a/src/main/java/com/infamous/dungeons_gear/capabilities/combo/ICombo.java
+++ b/src/main/java/com/infamous/dungeons_gear/capabilities/combo/ICombo.java
@@ -45,4 +45,9 @@ public interface ICombo {
     double getDynamoMultiplier();
     void setDynamoMultiplier(double dynamoMultiplier);
 
+    int getComboCount();
+    void setComboCount(int comboCount);
+
+    float getCachedCooldown();
+    void setCachedCooldown(float cooldown);
 }

--- a/src/main/java/com/infamous/dungeons_gear/enchantments/melee/CriticalHitEnchantment.java
+++ b/src/main/java/com/infamous/dungeons_gear/enchantments/melee/CriticalHitEnchantment.java
@@ -3,6 +3,7 @@ package com.infamous.dungeons_gear.enchantments.melee;
 import com.infamous.dungeons_gear.config.DungeonsGearConfig;
 import com.infamous.dungeons_gear.enchantments.types.AOEDamageEnchantment;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.utilties.ModEnchantmentHelper;
 import com.infamous.dungeons_gear.enchantments.ModEnchantmentTypes;
 import com.infamous.dungeons_gear.enchantments.types.DamageBoostEnchantment;
@@ -15,18 +16,52 @@ import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import static com.infamous.dungeons_gear.DungeonsGear.MODID;
 import static com.infamous.dungeons_gear.items.WeaponList.*;
 
-@Mod.EventBusSubscriber(modid= MODID)
+@Mod.EventBusSubscriber(modid = MODID)
 public class CriticalHitEnchantment extends DamageBoostEnchantment {
 
     public CriticalHitEnchantment() {
         super(Enchantment.Rarity.RARE, ModEnchantmentTypes.MELEE, new EquipmentSlotType[]{
                 EquipmentSlotType.MAINHAND});
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onVanillaNonCriticalHit(CriticalHitEvent event) {
+        if (event.getPlayer() != null && !event.isVanillaCritical()) {
+            PlayerEntity attacker = event.getPlayer();
+            ItemStack mainhand = attacker.getHeldItemMainhand();
+            boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.HAWKBRAND.get()
+                    || mainhand.getItem() == DeferredItemInit.MASTERS_KATANA.get()
+                    || mainhand.getItem() == DeferredItemInit.SINISTER_SWORD.get();
+            boolean success = false;
+            if (event.getResult() != Event.Result.ALLOW && mainhand.getItem() instanceof IComboWeapon) return;
+            if (ModEnchantmentHelper.hasEnchantment(mainhand, MeleeEnchantmentList.CRITICAL_HIT)) {
+                int criticalHitLevel = EnchantmentHelper.getEnchantmentLevel(MeleeEnchantmentList.CRITICAL_HIT, mainhand);
+                float criticalHitChance;
+                criticalHitChance = 0.05F + criticalHitLevel * 0.05F;
+                float criticalHitRand = attacker.getRNG().nextFloat();
+                if (criticalHitRand <= criticalHitChance) {
+                    success = true;
+                }
+            }
+            if (uniqueWeaponFlag) {
+                float criticalHitRand = attacker.getRNG().nextFloat();
+                if (criticalHitRand <= 0.1F) {
+                    success = true;
+                }
+            }
+            if (success) {
+                event.setResult(Event.Result.ALLOW);
+                float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() && !(mainhand.getItem() instanceof IComboWeapon) ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
+                event.setDamageModifier(newDamageModifier);
+            }
+        }
     }
 
     @Override
@@ -38,35 +73,5 @@ public class CriticalHitEnchantment extends DamageBoostEnchantment {
     public boolean canApplyTogether(Enchantment enchantment) {
         return DungeonsGearConfig.ENABLE_OVERPOWERED_ENCHANTMENT_COMBOS.get() ||
                 (!(enchantment instanceof DamageEnchantment) && !(enchantment instanceof DamageBoostEnchantment) && !(enchantment instanceof AOEDamageEnchantment));
-    }
-
-    @SubscribeEvent
-    public static void onVanillaNonCriticalHit(CriticalHitEvent event){
-        if(event.getPlayer() != null && !event.isVanillaCritical()){
-            PlayerEntity attacker = (PlayerEntity) event.getPlayer();
-            ItemStack mainhand = attacker.getHeldItemMainhand();
-            boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.HAWKBRAND.get()
-                    || mainhand.getItem() == DeferredItemInit.MASTERS_KATANA.get()
-                    || mainhand.getItem() == DeferredItemInit.SINISTER_SWORD.get();
-            if(ModEnchantmentHelper.hasEnchantment(mainhand, MeleeEnchantmentList.CRITICAL_HIT)){
-                int criticalHitLevel = EnchantmentHelper.getEnchantmentLevel(MeleeEnchantmentList.CRITICAL_HIT, mainhand);
-                float criticalHitChance;
-                criticalHitChance = 0.5F + criticalHitLevel * 0.05F;
-                float criticalHitRand = attacker.getRNG().nextFloat();
-                if(criticalHitRand <= criticalHitChance){
-                    event.setResult(Event.Result.ALLOW);
-                    float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
-                    event.setDamageModifier(newDamageModifier);
-                }
-            }
-            if(uniqueWeaponFlag){
-                float criticalHitRand = attacker.getRNG().nextFloat();
-                if(criticalHitRand <= 0.1F){
-                    event.setResult(Event.Result.ALLOW);
-                    float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
-                    event.setDamageModifier(newDamageModifier);
-                }
-            }
-        }
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/enchantments/melee/EchoEnchantment.java
+++ b/src/main/java/com/infamous/dungeons_gear/enchantments/melee/EchoEnchantment.java
@@ -1,5 +1,6 @@
 package com.infamous.dungeons_gear.enchantments.melee;
 
+import com.infamous.dungeons_gear.capabilities.combo.ICombo;
 import com.infamous.dungeons_gear.config.DungeonsGearConfig;
 import com.infamous.dungeons_gear.enchantments.ModEnchantmentTypes;
 import com.infamous.dungeons_gear.enchantments.lists.MeleeEnchantmentList;
@@ -7,6 +8,7 @@ import com.infamous.dungeons_gear.enchantments.types.AOEDamageEnchantment;
 import com.infamous.dungeons_gear.enchantments.types.DamageBoostEnchantment;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
 import com.infamous.dungeons_gear.utilties.AreaOfEffectHelper;
+import com.infamous.dungeons_gear.utilties.CapabilityHelper;
 import com.infamous.dungeons_gear.utilties.ModEnchantmentHelper;
 import net.minecraft.enchantment.DamageEnchantment;
 import net.minecraft.enchantment.Enchantment;
@@ -17,8 +19,12 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import java.util.Optional;
 
 import static com.infamous.dungeons_gear.DungeonsGear.MODID;
 
@@ -30,6 +36,30 @@ public class EchoEnchantment extends AOEDamageEnchantment {
                 EquipmentSlotType.MAINHAND});
     }
 
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onVanillaCriticalHit(CriticalHitEvent event) {
+        if (event.getPlayer() != null
+                && (event.getResult() == Event.Result.ALLOW || (event.getResult() == Event.Result.DEFAULT && event.isVanillaCritical()))
+        ) {
+            PlayerEntity attacker = (PlayerEntity) event.getPlayer();
+            LivingEntity victim = event.getEntityLiving();
+            ItemStack mainhand = attacker.getHeldItemMainhand();
+            boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.WHISPERING_SPEAR.get();
+            if (ModEnchantmentHelper.hasEnchantment(mainhand, MeleeEnchantmentList.ECHO) || uniqueWeaponFlag) {
+                int echoLevel = EnchantmentHelper.getEnchantmentLevel(MeleeEnchantmentList.ECHO, mainhand);
+                if (uniqueWeaponFlag) echoLevel++;
+                // gets the attack damage of the original attack before any enchantment modifiers are added
+                float attackDamage = (float) attacker.getAttributeValue(Attributes.ATTACK_DAMAGE);
+                ICombo ic = CapabilityHelper.getComboCapability(attacker);
+                float cooledAttackStrength = ic == null ? 1 : ic.getCachedCooldown();
+                attackDamage *= 0.2F + cooledAttackStrength * cooledAttackStrength * 0.8F;
+
+                // play echo sound, if there was one
+                AreaOfEffectHelper.causeEchoAttack(attacker, victim, attackDamage, 3.0f, echoLevel);
+            }
+        }
+    }
+
     public int getMaxLevel() {
         return 3;
     }
@@ -38,28 +68,5 @@ public class EchoEnchantment extends AOEDamageEnchantment {
     public boolean canApplyTogether(Enchantment enchantment) {
         return DungeonsGearConfig.ENABLE_OVERPOWERED_ENCHANTMENT_COMBOS.get() ||
                 (!(enchantment instanceof DamageEnchantment) && !(enchantment instanceof DamageBoostEnchantment) && !(enchantment instanceof AOEDamageEnchantment));
-    }
-
-    @SubscribeEvent
-    public static void onVanillaCriticalHit(CriticalHitEvent event){
-        if(event.getPlayer() != null
-            && event.isVanillaCritical()
-        ){
-            PlayerEntity attacker = (PlayerEntity) event.getPlayer();
-            LivingEntity victim = event.getEntityLiving();
-            ItemStack mainhand = attacker.getHeldItemMainhand();
-            boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.WHISPERING_SPEAR.get();
-            if(ModEnchantmentHelper.hasEnchantment(mainhand, MeleeEnchantmentList.ECHO) || uniqueWeaponFlag){
-                int echoLevel = EnchantmentHelper.getEnchantmentLevel(MeleeEnchantmentList.ECHO, mainhand);
-                if(uniqueWeaponFlag) echoLevel++;
-                // gets the attack damage of the original attack before any enchantment modifiers are added
-                float attackDamage = (float)attacker.getAttributeValue(Attributes.ATTACK_DAMAGE);
-                float cooledAttackStrength = attacker.getCooledAttackStrength(0.5F);
-                attackDamage *= 0.2F + cooledAttackStrength * cooledAttackStrength * 0.8F;
-
-                // play echo sound, if there was one
-                AreaOfEffectHelper.causeEchoAttack(attacker, victim, attackDamage, 3.0f, echoLevel);
-            }
-        }
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/enchantments/melee/ShockwaveEnchantment.java
+++ b/src/main/java/com/infamous/dungeons_gear/enchantments/melee/ShockwaveEnchantment.java
@@ -6,6 +6,7 @@ import com.infamous.dungeons_gear.enchantments.lists.MeleeEnchantmentList;
 import com.infamous.dungeons_gear.enchantments.types.AOEDamageEnchantment;
 import com.infamous.dungeons_gear.enchantments.types.DamageBoostEnchantment;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.utilties.AOECloudHelper;
 import com.infamous.dungeons_gear.utilties.AreaOfEffectHelper;
 import com.infamous.dungeons_gear.utilties.ModEnchantmentHelper;
@@ -20,6 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -49,11 +51,12 @@ public class ShockwaveEnchantment extends AOEDamageEnchantment {
     @SubscribeEvent
     public static void onVanillaCriticalHit(CriticalHitEvent event){
         if(event.getPlayer() != null
-                && event.isVanillaCritical()
+                && (event.getResult() == Event.Result.ALLOW || (event.getResult() == Event.Result.DEFAULT && event.isVanillaCritical()))
         ){
             PlayerEntity attacker = (PlayerEntity) event.getPlayer();
             LivingEntity victim = event.getEntityLiving();
             ItemStack mainhand = attacker.getHeldItemMainhand();
+            if (event.getResult() != Event.Result.ALLOW && mainhand.getItem() instanceof IComboWeapon) return;
             boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.WHIRLWIND.get();
             if(ModEnchantmentHelper.hasEnchantment(mainhand, MeleeEnchantmentList.SHOCKWAVE) || uniqueWeaponFlag){
                 int shockwaveLevel = EnchantmentHelper.getEnchantmentLevel(MeleeEnchantmentList.SHOCKWAVE, mainhand);

--- a/src/main/java/com/infamous/dungeons_gear/enchantments/melee_ranged/EnigmaResonatorEnchantment.java
+++ b/src/main/java/com/infamous/dungeons_gear/enchantments/melee_ranged/EnigmaResonatorEnchantment.java
@@ -6,6 +6,7 @@ import com.infamous.dungeons_gear.enchantments.lists.MeleeRangedEnchantmentList;
 import com.infamous.dungeons_gear.enchantments.types.AOEDamageEnchantment;
 import com.infamous.dungeons_gear.enchantments.types.DamageBoostEnchantment;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.utilties.ModEnchantmentHelper;
 import net.minecraft.enchantment.DamageEnchantment;
 import net.minecraft.enchantment.Enchantment;
@@ -17,18 +18,56 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import static com.infamous.dungeons_gear.DungeonsGear.MODID;
 import static com.infamous.dungeons_gear.DungeonsGear.PROXY;
 
-@Mod.EventBusSubscriber(modid= MODID)
+@Mod.EventBusSubscriber(modid = MODID)
 public class EnigmaResonatorEnchantment extends DamageBoostEnchantment {
 
     public EnigmaResonatorEnchantment() {
         super(Rarity.RARE, ModEnchantmentTypes.MELEE_RANGED, new EquipmentSlotType[]{
-            EquipmentSlotType.MAINHAND});
+                EquipmentSlotType.MAINHAND});
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onVanillaNonCriticalHit(CriticalHitEvent event) {
+        if (event.getPlayer() == null) return;
+        PlayerEntity attacker = event.getPlayer();
+        LivingEntity victim = event.getEntityLiving();
+        ItemStack mainhand = attacker.getHeldItemMainhand();
+        boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.SOUL_FIST.get()
+                || mainhand.getItem() == DeferredItemInit.MOON_DAGGER.get();
+
+        int numSouls = Math.min(attacker.experienceTotal, 50);
+        if (!event.isVanillaCritical()) {
+            boolean success = false;
+            if (ModEnchantmentHelper.hasEnchantment(mainhand, MeleeRangedEnchantmentList.ENIGMA_RESONATOR)) {
+                int enigmaResonatorLevel = EnchantmentHelper.getEnchantmentLevel(MeleeRangedEnchantmentList.ENIGMA_RESONATOR, mainhand);
+                float soulsCriticalBoostChanceCap;
+                soulsCriticalBoostChanceCap = 0.1F + 0.05F * enigmaResonatorLevel;
+                float soulsCriticalBoostRand = attacker.getRNG().nextFloat();
+                if (soulsCriticalBoostRand <= Math.min(numSouls / 50.0, soulsCriticalBoostChanceCap)) {
+                    success = true;
+                }
+            }
+            if (uniqueWeaponFlag) {
+                float soulsCriticalBoostRand = attacker.getRNG().nextFloat();
+                if (soulsCriticalBoostRand <= Math.min(numSouls / 50.0, 0.15F)) {
+                    success = true;
+                }
+            }
+            if (success) {
+                event.setResult(Event.Result.ALLOW);
+                float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() && !(mainhand.getItem() instanceof IComboWeapon) ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
+                event.setDamageModifier(newDamageModifier);
+                // soul particles
+                PROXY.spawnParticles(attacker, ParticleTypes.SOUL);
+            }
+        }
     }
 
     @Override
@@ -40,42 +79,5 @@ public class EnigmaResonatorEnchantment extends DamageBoostEnchantment {
     public boolean canApplyTogether(Enchantment enchantment) {
         return DungeonsGearConfig.ENABLE_OVERPOWERED_ENCHANTMENT_COMBOS.get() ||
                 (!(enchantment instanceof DamageEnchantment) && !(enchantment instanceof DamageBoostEnchantment) && !(enchantment instanceof AOEDamageEnchantment));
-    }
-
-    @SubscribeEvent
-    public static void onVanillaNonCriticalHit(CriticalHitEvent event){
-        if(event.getPlayer() == null) return;
-        PlayerEntity attacker = event.getPlayer();
-        LivingEntity victim = event.getEntityLiving();
-        ItemStack mainhand = attacker.getHeldItemMainhand();
-        boolean uniqueWeaponFlag = mainhand.getItem() == DeferredItemInit.SOUL_FIST.get()
-                || mainhand.getItem() == DeferredItemInit.MOON_DAGGER.get();
-
-        int numSouls = Math.min(attacker.experienceTotal, 50);
-        if(!event.isVanillaCritical()){
-            if(ModEnchantmentHelper.hasEnchantment(mainhand, MeleeRangedEnchantmentList.ENIGMA_RESONATOR)){
-                int enigmaResonatorLevel = EnchantmentHelper.getEnchantmentLevel(MeleeRangedEnchantmentList.ENIGMA_RESONATOR, mainhand);
-                float soulsCriticalBoostChanceCap;
-                soulsCriticalBoostChanceCap = 0.1F + 0.05F * enigmaResonatorLevel;
-                float soulsCriticalBoostRand = attacker.getRNG().nextFloat();
-                if(soulsCriticalBoostRand <= Math.min(numSouls/50.0, soulsCriticalBoostChanceCap)){
-                    event.setResult(Event.Result.ALLOW);
-                    float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
-                    event.setDamageModifier(newDamageModifier);
-                    // soul particles
-                    PROXY.spawnParticles(attacker, ParticleTypes.SOUL);
-                }
-            }
-            if(uniqueWeaponFlag){
-                float soulsCriticalBoostRand = attacker.getRNG().nextFloat();
-                if(soulsCriticalBoostRand <= Math.min(numSouls/50.0, 0.15F)){
-                    event.setResult(Event.Result.ALLOW);
-                    float newDamageModifier = event.getDamageModifier() == event.getOldDamageModifier() ? event.getDamageModifier() + 1.5F : event.getDamageModifier() * 3.0F;
-                    event.setDamageModifier(newDamageModifier);
-                    // soul particles
-                    PROXY.spawnParticles(attacker, ParticleTypes.SOUL);
-                }
-            }
-        }
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/interfaces/IComboWeapon.java
+++ b/src/main/java/com/infamous/dungeons_gear/interfaces/IComboWeapon.java
@@ -1,0 +1,16 @@
+package com.infamous.dungeons_gear.interfaces;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+public interface IComboWeapon {
+    int getComboLength(ItemStack stack, LivingEntity attacker);
+
+    default boolean shouldProcSpecialEffects(ItemStack stack, LivingEntity attacker, int combo) {
+        return combo % getComboLength(stack, attacker) == 0;
+    }
+
+//    default float damageMultiplier(ItemStack stack, LivingEntity attacker, int combo) {
+//        return 1.5f;
+//    }
+}

--- a/src/main/java/com/infamous/dungeons_gear/melee/ClaymoreItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/ClaymoreItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,7 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class ClaymoreItem extends SwordItem implements IMeleeWeapon {
+public class ClaymoreItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
 
     private final boolean unique;
 
@@ -62,5 +64,10 @@ public class ClaymoreItem extends SwordItem implements IMeleeWeapon {
             list.add(new StringTextComponent(TextFormatting.GREEN + "Powerful Pushback"));
 
         }
+    }
+
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/melee/CutlassItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/CutlassItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,7 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class CutlassItem extends SwordItem implements IMeleeWeapon {
+public class CutlassItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
     private final boolean unique;
 
     public CutlassItem(IItemTier tier, int attackDamageIn, float attackSpeedIn, Properties builder, boolean isUnique) {
@@ -52,5 +54,10 @@ public class CutlassItem extends SwordItem implements IMeleeWeapon {
             //list.add(new StringTextComponent(TextFormatting.GREEN + "Reliable Combo"));
 
         }
+    }
+
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 2;
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/melee/DaggerItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/DaggerItem.java
@@ -5,10 +5,12 @@ import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.combat.CombatEventHandler;
 import com.infamous.dungeons_gear.compat.DungeonsGearCompatibility;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.interfaces.IOffhandAttack;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
@@ -29,7 +31,11 @@ import net.minecraft.world.World;
 import java.util.List;
 import java.util.UUID;
 
-public class DaggerItem extends SwordItem implements IOffhandAttack, IMeleeWeapon, ISoulGatherer {
+public class DaggerItem extends SwordItem implements IOffhandAttack, IMeleeWeapon, ISoulGatherer , IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 6;
+    }
     private static final UUID ATTACK_DAMAGE_MODIFIER_OFF = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A34DB5CF");
     private final boolean unique;
     private final Multimap<Attribute, AttributeModifier> attributeModifiersMain, attributeModifiersOff;

--- a/src/main/java/com/infamous/dungeons_gear/melee/DoubleAxeItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/DoubleAxeItem.java
@@ -1,6 +1,7 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
@@ -16,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class DoubleAxeItem extends AxeItem implements IMeleeWeapon {
+public class DoubleAxeItem extends AxeItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 2;
+    }
     private final boolean unique;
 
     public DoubleAxeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties builder, boolean isUnique) {

--- a/src/main/java/com/infamous/dungeons_gear/melee/DungeonsAxeItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/DungeonsAxeItem.java
@@ -1,6 +1,7 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
@@ -16,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class DungeonsAxeItem extends AxeItem implements IMeleeWeapon {
+public class DungeonsAxeItem extends AxeItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
     public DungeonsAxeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties builder, boolean isUnique) {

--- a/src/main/java/com/infamous/dungeons_gear/melee/DungeonsPickaxeItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/DungeonsPickaxeItem.java
@@ -1,6 +1,7 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.enchantment.Enchantment;
@@ -15,7 +16,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class DungeonsPickaxeItem extends PickaxeItem implements IMeleeWeapon {
+public class DungeonsPickaxeItem extends PickaxeItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 1;
+    }
     private final boolean unique;
     public DungeonsPickaxeItem(IItemTier tier, int attackDamageIn, float attackSpeedIn, Properties builder, boolean isUnique) {
         super(tier, attackDamageIn, attackSpeedIn, builder);

--- a/src/main/java/com/infamous/dungeons_gear/melee/DungeonsSwordItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/DungeonsSwordItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class DungeonsSwordItem extends net.minecraft.item.SwordItem implements IMeleeWeapon {
+public class DungeonsSwordItem extends net.minecraft.item.SwordItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/GauntletItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/GauntletItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.combat.CombatEventHandler;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.interfaces.IOffhandAttack;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
@@ -32,12 +33,11 @@ import java.util.List;
 import java.util.UUID;
 
 
-public class GauntletItem extends TieredItem implements IOffhandAttack, IVanishable, IMeleeWeapon, ISoulGatherer {
+public class GauntletItem extends TieredItem implements IOffhandAttack, IVanishable, IMeleeWeapon, ISoulGatherer, IComboWeapon {
     private static final UUID ATTACK_DAMAGE_MODIFIER_OFF = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A34DB5CF");
     private final boolean unique;
     private final float attackDamage;
     private final Multimap<Attribute, AttributeModifier> attributeModifiersMain, attributeModifiersOff;
-
     public GauntletItem(IItemTier tier, int attackDamageIn, float attackSpeedIn, Item.Properties properties, boolean isUnique) {
         super(tier, properties);
         this.attackDamage = (float) attackDamageIn + tier.getAttackDamage();
@@ -49,6 +49,11 @@ public class GauntletItem extends TieredItem implements IOffhandAttack, IVanisha
         builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(ATTACK_DAMAGE_MODIFIER_OFF, "Weapon modifier", attackDamageIn, AttributeModifier.Operation.ADDITION));
         this.attributeModifiersOff = builder.build();
         this.unique = isUnique;
+    }
+
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return stack.getItem() == DeferredItemInit.FIGHTERS_BINDING.get() ? 4 : 7;
     }
 
     // Only used by MobEntity class for determining sword changes

--- a/src/main/java/com/infamous/dungeons_gear/melee/GlaiveItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/GlaiveItem.java
@@ -6,10 +6,12 @@ import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.compat.DungeonsGearCompatibility;
 import com.infamous.dungeons_gear.init.AttributeRegistry;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IExtendedAttackReach;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
@@ -27,7 +29,11 @@ import net.minecraftforge.common.ForgeMod;
 import java.util.List;
 import java.util.UUID;
 
-public class GlaiveItem extends SwordItem implements IMeleeWeapon {
+public class GlaiveItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
     private final float attackDamage;

--- a/src/main/java/com/infamous/dungeons_gear/melee/GreatHammerItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/GreatHammerItem.java
@@ -3,6 +3,7 @@ package com.infamous.dungeons_gear.melee;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.block.BlockState;
@@ -27,7 +28,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class GreatHammerItem extends TieredItem implements IMeleeWeapon {
+public class GreatHammerItem extends TieredItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 1;
+    }
 
     private final boolean unique;
     private final float attackDamage;

--- a/src/main/java/com/infamous/dungeons_gear/melee/KatanaItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/KatanaItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class KatanaItem extends SwordItem implements IMeleeWeapon {
+public class KatanaItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/MaceItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/MaceItem.java
@@ -3,6 +3,7 @@ package com.infamous.dungeons_gear.melee;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.block.BlockState;
@@ -24,7 +25,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class MaceItem extends TieredItem implements IMeleeWeapon {
+public class MaceItem extends TieredItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
     private final float attackDamage;

--- a/src/main/java/com/infamous/dungeons_gear/melee/RapierItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/RapierItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class RapierItem extends SwordItem implements IMeleeWeapon {
+public class RapierItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 14;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/SickleItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/SickleItem.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.combat.CombatEventHandler;
 import com.infamous.dungeons_gear.compat.DungeonsGearCompatibility;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IOffhandAttack;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
@@ -34,7 +35,11 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import java.util.List;
 import java.util.UUID;
 
-public class SickleItem extends SwordItem implements IOffhandAttack, IMeleeWeapon {
+public class SickleItem extends SwordItem implements IOffhandAttack, IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 6;
+    }
     private static final UUID ATTACK_DAMAGE_MODIFIER_OFF = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A34DB5CF");
 
     private final boolean unique;

--- a/src/main/java/com/infamous/dungeons_gear/melee/SoulKnifeItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/SoulKnifeItem.java
@@ -1,10 +1,12 @@
 package com.infamous.dungeons_gear.melee;
 
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -16,7 +18,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class SoulKnifeItem extends SwordItem implements IMeleeWeapon, ISoulGatherer {
+public class SoulKnifeItem extends SwordItem implements IMeleeWeapon, ISoulGatherer, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 1;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/SoulScytheItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/SoulScytheItem.java
@@ -4,6 +4,7 @@ package com.infamous.dungeons_gear.melee;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
 import com.infamous.dungeons_gear.items.WeaponList;
@@ -32,7 +33,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class SoulScytheItem extends SwordItem implements IMeleeWeapon, ISoulGatherer {
+public class SoulScytheItem extends SwordItem implements IMeleeWeapon, ISoulGatherer, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 2;
+    }
 
     private final boolean unique;
     public SoulScytheItem(IItemTier tier, int attackDamageIn, float attackSpeedIn, Properties properties, boolean isUnique) {

--- a/src/main/java/com/infamous/dungeons_gear/melee/SpearItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/SpearItem.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.compat.DungeonsGearCompatibility;
 import com.infamous.dungeons_gear.init.AttributeRegistry;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.block.BlockState;
@@ -32,7 +33,11 @@ import net.minecraftforge.common.ForgeMod;
 import java.util.List;
 import java.util.UUID;
 
-public class SpearItem extends TieredItem implements IMeleeWeapon {
+public class SpearItem extends TieredItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private static final UUID ATTACK_REACH_MODIFIER = UUID.fromString("63d316c1-7d6d-41be-81c3-41fc1a216c27");
     private final boolean unique;

--- a/src/main/java/com/infamous/dungeons_gear/melee/StaffItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/StaffItem.java
@@ -3,6 +3,7 @@ package com.infamous.dungeons_gear.melee;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.block.BlockState;
@@ -22,7 +23,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class StaffItem extends TieredItem implements IMeleeWeapon {
+public class StaffItem extends TieredItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 10;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/TempestKnifeItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/TempestKnifeItem.java
@@ -1,9 +1,11 @@
 package com.infamous.dungeons_gear.melee;
 
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.interfaces.ISoulGatherer;
 import com.infamous.dungeons_gear.items.WeaponList;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
@@ -15,7 +17,11 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class TempestKnifeItem extends SwordItem implements IMeleeWeapon{
+public class TempestKnifeItem extends SwordItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 3;
+    }
 
     private final boolean unique;
 

--- a/src/main/java/com/infamous/dungeons_gear/melee/WhipItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/melee/WhipItem.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import com.infamous.dungeons_gear.compat.DungeonsGearCompatibility;
 import com.infamous.dungeons_gear.init.AttributeRegistry;
 import com.infamous.dungeons_gear.init.DeferredItemInit;
+import com.infamous.dungeons_gear.interfaces.IComboWeapon;
 import com.infamous.dungeons_gear.interfaces.IExtendedAttackReach;
 import com.infamous.dungeons_gear.interfaces.IMeleeWeapon;
 import com.infamous.dungeons_gear.items.WeaponList;
@@ -29,7 +30,11 @@ import net.minecraftforge.common.ForgeMod;
 import java.util.List;
 import java.util.UUID;
 
-public class WhipItem extends TieredItem implements IMeleeWeapon {
+public class WhipItem extends TieredItem implements IMeleeWeapon, IComboWeapon {
+    @Override
+    public int getComboLength(ItemStack stack, LivingEntity attacker) {
+        return 1;
+    }
 
     private final boolean unique;
     private final float attackDamage;

--- a/src/main/java/com/infamous/dungeons_gear/mixin/AreaEffectCloudEntityMixin.java
+++ b/src/main/java/com/infamous/dungeons_gear/mixin/AreaEffectCloudEntityMixin.java
@@ -1,0 +1,41 @@
+package com.infamous.dungeons_gear.mixin;
+
+import com.infamous.dungeons_gear.utilties.AbilityHelper;
+import net.minecraft.entity.AreaEffectCloudEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.potion.Effect;
+import net.minecraft.potion.EffectInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import javax.annotation.Nullable;
+
+@Mixin(AreaEffectCloudEntity.class)
+public abstract class AreaEffectCloudEntityMixin {
+
+    @Shadow
+    @Nullable
+    public abstract LivingEntity getOwner();
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/potion/Effect;affectEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/LivingEntity;ID)V"), method = "tick")
+    private void instantHack(Effect effect, Entity source, Entity indirectSource, LivingEntity entityLivingBaseIn, int amplifier, double health) {
+        if (indirectSource instanceof LivingEntity) {
+            if (effect.isBeneficial() != AbilityHelper.canApplyToEnemy((LivingEntity) indirectSource, entityLivingBaseIn)) {
+                effect.affectEntity(source, indirectSource, entityLivingBaseIn, amplifier, health);
+            }
+        } else effect.affectEntity(source, indirectSource, entityLivingBaseIn, amplifier, health);
+    }
+
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;addPotionEffect(Lnet/minecraft/potion/EffectInstance;)Z"), method = "tick")
+    private boolean extendedHack(LivingEntity livingEntity, EffectInstance effectInstanceIn) {
+        if (getOwner()!=null) {
+            if (effectInstanceIn.getPotion().isBeneficial() != AbilityHelper.canApplyToEnemy(getOwner(), livingEntity)) {
+                livingEntity.addPotionEffect(effectInstanceIn);
+            }
+        } else livingEntity.addPotionEffect(effectInstanceIn);
+        return false;
+    }
+}

--- a/src/main/java/com/infamous/dungeons_gear/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/infamous/dungeons_gear/mixin/PlayerEntityMixin.java
@@ -1,6 +1,11 @@
 package com.infamous.dungeons_gear.mixin;
 
+import com.infamous.dungeons_gear.capabilities.CapabilityHandler;
+import com.infamous.dungeons_gear.capabilities.combo.Combo;
+import com.infamous.dungeons_gear.capabilities.combo.ComboProvider;
+import com.infamous.dungeons_gear.capabilities.combo.ICombo;
 import com.infamous.dungeons_gear.init.AttributeRegistry;
+import com.infamous.dungeons_gear.utilties.CapabilityHelper;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.AttributeModifierMap;
@@ -11,12 +16,21 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin extends LivingEntity {
     protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType_1, World world_1) {
         super(entityType_1, world_1);
+    }
+
+    @Inject(
+            method = "func_234570_el_",
+            at = @At("RETURN")
+    )
+    private static void initAttributes(CallbackInfoReturnable<AttributeModifierMap.MutableAttribute> ci) {
+        ci.getReturnValue().createMutableAttribute(AttributeRegistry.ATTACK_REACH.get());
     }
 
     @ModifyConstant(
@@ -29,10 +43,15 @@ public abstract class PlayerEntityMixin extends LivingEntity {
     }
 
     @Inject(
-            method = "func_234570_el_",
-            at = @At("RETURN")
+            method = "resetCooldown",
+            at = @At("HEAD")
     )
-    private static void initAttributes(CallbackInfoReturnable<AttributeModifierMap.MutableAttribute> ci) {
-        ci.getReturnValue().createMutableAttribute(AttributeRegistry.ATTACK_REACH.get());
+    private void resetCooldown(CallbackInfo ci) {
+        ICombo ic = CapabilityHelper.getComboCapability(this);
+        if (ic != null) {
+            ic.setComboCount(ic.getComboCount() + 1);
+            ic.setComboTimer(60);
+            ic.setCachedCooldown(((PlayerEntity) (Object) this).getCooledAttackStrength(0.5f));
+        }
     }
 }

--- a/src/main/java/com/infamous/dungeons_gear/utilties/AbilityHelper.java
+++ b/src/main/java/com/infamous/dungeons_gear/utilties/AbilityHelper.java
@@ -108,7 +108,7 @@ public class AbilityHelper {
                 && isAliveAndCanBeSeen(nearbyEntity, healer);
     }
 
-    private static boolean isAlly(LivingEntity healer, LivingEntity nearbyEntity) {
+    public static boolean isAlly(LivingEntity healer, LivingEntity nearbyEntity) {
         return isPetOfAttacker(healer, nearbyEntity)
         || isAVillagerOrIronGolem(nearbyEntity)
         || healer.isOnSameTeam(nearbyEntity);

--- a/src/main/resources/dungeons_gear.mixins.json
+++ b/src/main/resources/dungeons_gear.mixins.json
@@ -5,16 +5,17 @@
   "minVersion": "0.8",
   "refmap": "dungeons_gear.refmap.json",
   "mixins": [
-    "CrossbowItemMixin",
+    "AreaEffectCloudEntityMixin",
     "BowItemMixin",
-    "LockableLootTileEntityMixin",
     "ContainerMinecartEntityMixin",
-    "PlayerEntityMixin",
-    "HurtByTargetGoalMixin"
+    "CrossbowItemMixin",
+    "HurtByTargetGoalMixin",
+    "LockableLootTileEntityMixin",
+    "PlayerEntityMixin"
   ],
   "client": [
-    "PlayerRendererMixin",
-    "GameRendererMixin"
+    "GameRendererMixin",
+    "PlayerRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
crits are no longer on jump for dungeons weapons, being automatically triggered when attacking enough times. This means swirling and other enchantments that trigger on crit now trigger at the end of a combo like in dungeons itself. Crit damage has been dropped down to 1x for this purpose. Potion effect clouds no longer affect allies if they are harmful or enemies if they are helpful, so you can radiance shot with impunity. Fixed critical hit and enigma resonator having a very small chance of dealing 9x damage, echo not dealing enough damage, and some other stuff here or there.