### PR TITLE
optional aoecloud mixin, capability fix, broadsword fix

### DIFF
--- a/src/main/java/com/infamous/dungeons_gear/capabilities/CapabilityHandler.java
+++ b/src/main/java/com/infamous/dungeons_gear/capabilities/CapabilityHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.passive.*;
 import net.minecraft.entity.passive.horse.LlamaEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ShootableItem;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -30,10 +31,11 @@ public class CapabilityHandler {
 
     @SubscribeEvent
     public static void onAttachItemCapabilities(AttachCapabilitiesEvent<ItemStack> event) {
-        event.addCapability(new ResourceLocation(DungeonsGear.MODID, "weapon"), new WeaponProvider());
+        if (event.getObject().getItem() instanceof ShootableItem)
+            event.addCapability(new ResourceLocation(DungeonsGear.MODID, "weapon"), new WeaponProvider());
     }
 
-    private static boolean isSummonableEntity(Entity entity){
+    private static boolean isSummonableEntity(Entity entity) {
         return entity instanceof IronGolemEntity
                 || entity instanceof WolfEntity
                 || entity instanceof LlamaEntity

--- a/src/main/java/com/infamous/dungeons_gear/init/ItemRegistry.java
+++ b/src/main/java/com/infamous/dungeons_gear/init/ItemRegistry.java
@@ -164,7 +164,7 @@ public class ItemRegistry {
     public static final RegistryObject<Item> CLAYMORE = ITEMS.register("claymore",
             () -> new ClaymoreItem(ToolMaterialList.METAL, 11, (0.9f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), false));
     public static final RegistryObject<Item> BROADSWORD = ITEMS.register("broadsword",
-            () -> new ClaymoreItem(ToolMaterialList.METAL, 11, (0.9f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
+            () -> new ClaymoreItem(ToolMaterialList.METAL, 12, (0.9f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
     public static final RegistryObject<Item> HEARTSTEALER = ITEMS.register("heartstealer",
             () -> new ClaymoreItem(ToolMaterialList.METAL, 11, (0.9f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
     public static final RegistryObject<Item> GREAT_AXEBLADE = ITEMS.register("great_axeblade",
@@ -196,9 +196,9 @@ public class ItemRegistry {
     public static final RegistryObject<Item> TEMPEST_KNIFE = ITEMS.register("tempest_knife",
             () -> new TempestKnifeItem(ToolMaterialList.METAL, 2, (2.4f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), false));
     public static final RegistryObject<Item> RESOLUTE_TEMPEST_KNIFE = ITEMS.register("resolute_tempest_knife",
-            () -> new TempestKnifeItem(ToolMaterialList.METAL, 6, (1.0f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
+            () -> new TempestKnifeItem(ToolMaterialList.METAL, 2, (2.4f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
     public static final RegistryObject<Item> CHILL_GALE_KNIFE = ITEMS.register("chill_gale_knife",
-            () -> new TempestKnifeItem(ToolMaterialList.METAL, 6, (1.0f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
+            () -> new TempestKnifeItem(ToolMaterialList.METAL, 2, (2.4f-4.0f), new Item.Properties().group(DungeonsGear.MELEE_WEAPON_GROUP), true));
 
     public static final RegistryObject<Item> BONEBOW = ITEMS.register("bonebow",
             () -> new DungeonsBowItem(new Item.Properties(), 20.0F, true));

--- a/src/main/java/com/infamous/dungeons_gear/mixin/AreaEffectCloudEntityMixin.java
+++ b/src/main/java/com/infamous/dungeons_gear/mixin/AreaEffectCloudEntityMixin.java
@@ -20,7 +20,7 @@ public abstract class AreaEffectCloudEntityMixin {
     @Nullable
     public abstract LivingEntity getOwner();
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/potion/Effect;affectEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/LivingEntity;ID)V"), method = "tick")
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/potion/Effect;affectEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/LivingEntity;ID)V"), method = "tick", require = 0)
     private void instantHack(Effect effect, Entity source, Entity indirectSource, LivingEntity entityLivingBaseIn, int amplifier, double health) {
         if (indirectSource instanceof LivingEntity) {
             if (effect.isBeneficial() != AbilityHelper.canApplyToEnemy((LivingEntity) indirectSource, entityLivingBaseIn)) {
@@ -29,7 +29,7 @@ public abstract class AreaEffectCloudEntityMixin {
         } else effect.affectEntity(source, indirectSource, entityLivingBaseIn, amplifier, health);
     }
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;addPotionEffect(Lnet/minecraft/potion/EffectInstance;)Z"), method = "tick")
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;addPotionEffect(Lnet/minecraft/potion/EffectInstance;)Z"), method = "tick", require = 0)
     private boolean extendedHack(LivingEntity livingEntity, EffectInstance effectInstanceIn) {
         if (getOwner()!=null) {
             if (effectInstanceIn.getPotion().isBeneficial() != AbilityHelper.canApplyToEnemy(getOwner(), livingEntity)) {


### PR DESCRIPTION
AreaOfEffectCloudEntityMixin is now completely optional, for Mohist reasons. Combat capability is only attached to instances of ShootableItem, to fix some bugs with other mods. Broadsword bumped up to 13 damage.