### PR TITLE
Fix packets

### DIFF
--- a/src/main/java/com/infamous/dungeons_gear/DungeonsGear.java
+++ b/src/main/java/com/infamous/dungeons_gear/DungeonsGear.java
@@ -88,9 +88,7 @@ public class DungeonsGear
 
     private void setup(final FMLCommonSetupEvent event)
     {
-        DeferredWorkQueue.runLater(
-                NetworkHandler::init
-        );
+        NetworkHandler.init();
         ItemRegistry.putItemsInMap();
         WeaponAttributeHandler.setWeaponAttributeModifiers();
         CapabilityManager.INSTANCE.register(ISummonable.class, new SummonableStorage(), Summonable::new);

--- a/src/main/java/com/infamous/dungeons_gear/combat/PacketBreakItem.java
+++ b/src/main/java/com/infamous/dungeons_gear/combat/PacketBreakItem.java
@@ -6,6 +6,9 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.DistExecutor.SafeRunnable;
 import net.minecraftforge.fml.network.NetworkEvent;
 
 import java.util.function.Supplier;
@@ -31,18 +34,22 @@ public class PacketBreakItem {
     public static class BreakItemHandler {
         public static void handle(PacketBreakItem packet, Supplier<NetworkEvent.Context> ctx) {
             if (packet != null) {
-                ((NetworkEvent.Context) ctx.get()).enqueueWork(new Runnable() {
+                ctx.get().enqueueWork(() -> DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> new SafeRunnable() {
+
+                    private static final long serialVersionUID = 1;
+
                     @Override
                     public void run() {
                         ClientWorld world = Minecraft.getInstance().world;
-                        Entity target=null;
-                        if(world!=null)target=world.getEntityByID(packet.entityID);
+                        Entity target = null;
+                        if (world != null)
+                            target = world.getEntityByID(packet.entityID);
                         if (target instanceof LivingEntity) {
                             ((LivingEntity) target).renderBrokenItemStack(packet.stack);
                         }
-
                     }
-                });
+
+                }));
             }
         }
     }

--- a/src/main/java/com/infamous/dungeons_gear/combat/PacketOffhandAttack.java
+++ b/src/main/java/com/infamous/dungeons_gear/combat/PacketOffhandAttack.java
@@ -33,6 +33,7 @@ public class PacketOffhandAttack {
 
         public static void handle(PacketOffhandAttack packet, Supplier<NetworkEvent.Context> ctx) {
             if (packet != null) {
+                ctx.get().setPacketHandled(true);
                 ((NetworkEvent.Context)ctx.get()).enqueueWork(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
When I forked the repo and tried to run the latest changes on a dedicated server, the player could not join because the server was complaining about unknown packets. Therefore I changed the setup() method to call NetworkHandler.init() directly, which had the unfortunate side effects of immediately crashing the server on startup due to missing class exceptions. To fix this I switched to using DistExecutor.safeRunWhenOn for the packets which is the preferred was of doing things.

In addition to this I added the call to ctx.get().setPacketHandled(true) for every packet to avoid the console spamming about "Unknown custom packet identifier".
